### PR TITLE
Accept strings of the form "0x0p0", with no dot.

### DIFF
--- a/parse/src/lib.rs
+++ b/parse/src/lib.rs
@@ -289,6 +289,10 @@ fn test_parse() {
     assert_eq!(parse(b"0x0_p0", true), Ok((false, 0, 0)));
     assert_eq!(parse(b"0x.0_p0", true), Ok((false, 0, 0)));
     assert_eq!(parse(b"0x0.0_p0", true), Ok((false, 0, 0)));
+
+    // issues
+    // #11 (https://github.com/lifthrasiir/hexf/issues/11)
+    assert_eq!(parse(b"0x1p-149", false), parse(b"0x1.0p-149", false));
 }
 
 macro_rules! define_convert {


### PR DESCRIPTION
GLIBC's and musl's printf with %a formats zero as "0x0p+0", with no dot, so
accept strings of that form.