### PR TITLE
modernize: remove proc macro hack

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: rust
 sudo: false
 rust:
-  - 1.15.0
+  - 1.45.0
   - stable
   - beta
   - nightly

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hexf"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Kang Seonghoon <public+rust@mearie.org>"]
 
 description = "Hexadecimal float support for Rust"
@@ -15,6 +15,6 @@ edition = "2018"
 members = ["parse/", "impl/"]
 
 [dependencies]
-hexf-parse = { version = "0.1.0", path = "parse/" }
-hexf-impl = { version = "0.1.0", path = "impl/" }
+hexf-parse = { version = "0.2.0", path = "parse/" }
+hexf-impl = { version = "0.2.0", path = "impl/" }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,12 +9,12 @@ documentation = "https://docs.rs/hexf/"
 repository = "https://github.com/lifthrasiir/hexf"
 readme = "README.md"
 license = "CC0-1.0"
+edition = "2018"
 
 [workspace]
 members = ["parse/", "impl/"]
 
 [dependencies]
-proc-macro-hack = "0.3.3"
 hexf-parse = { version = "0.1.0", path = "parse/" }
 hexf-impl = { version = "0.1.0", path = "impl/" }
 

--- a/README.md
+++ b/README.md
@@ -11,10 +11,10 @@
 [docsrs-image]: https://docs.rs/hexf/badge.svg
 [docsrs]: https://docs.rs/hexf/
 
-Hexadecimal float support for Rust 1.15 or later.
+Hexadecimal float support for Rust 1.45 or later.
 
 ```rust
-#[macro_use] extern crate hexf;
+use hexf::hexf64;
 
 assert_eq!(hexf64!("0x1.999999999999ap-4"), 0.1f64);
 ```

--- a/impl/Cargo.toml
+++ b/impl/Cargo.toml
@@ -8,12 +8,12 @@ homepage = "https://github.com/lifthrasiir/hexf"
 documentation = "https://docs.rs/hexf/"
 repository = "https://github.com/lifthrasiir/hexf"
 license = "CC0-1.0"
+edition = "2018"
 
 [lib]
 proc-macro = true
 
 [dependencies]
-proc-macro-hack = "0.3.3"
-syn = "0.15"
+syn = "1.0.41"
 hexf-parse = { version = "0.1.0", path = "../parse/" }
 

--- a/impl/Cargo.toml
+++ b/impl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hexf-impl"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Kang Seonghoon <public+rust@mearie.org>"]
 
 description = "Hexadecimal float support for Rust (auxiliary crate; see also hexf)"
@@ -15,5 +15,4 @@ proc-macro = true
 
 [dependencies]
 syn = "1.0.41"
-hexf-parse = { version = "0.1.0", path = "../parse/" }
-
+hexf-parse = { version = "0.2.0", path = "../parse/" }

--- a/impl/src/lib.rs
+++ b/impl/src/lib.rs
@@ -1,30 +1,43 @@
 //! Support library for `hexf`. Do not use directly.
 
-#[macro_use] extern crate proc_macro_hack;
-extern crate syn;
-extern crate hexf_parse;
+use proc_macro::TokenStream;
 
-proc_macro_expr_impl! {
-    /// Support function for `hexf32!` macro. Do not use directly.
-    #[doc(hidden)]
-    pub fn hexf32_impl(input: &str) -> String {
-        let lit = syn::parse_str::<syn::LitStr>(input).expect("hexf32! requires a single string literal");
-        match hexf_parse::parse_hexf32(&lit.value(), true) {
-            Ok(v) => format!("{:?}f32", v), // should keep the sign even for -0.0
-            Err(e) => panic!("hexf32! failed: {}", e),
-        }
+/// Expands to a `f32` value with given hexadecimal representation.
+///
+/// # Example
+///
+/// ```rust
+/// # use hexf::hexf32; fn main() {
+/// assert_eq!(hexf32!("0x1.99999ap-4"), 0.1f32);
+/// # }
+/// ```
+#[proc_macro]
+pub fn hexf32(input: TokenStream) -> TokenStream {
+    let lit = syn::parse_macro_input!(input as syn::LitStr);
+    match hexf_parse::parse_hexf32(&lit.value(), true) {
+        Ok(v) => format!("{:?}f32", v) // should keep the sign even for -0.0
+            .parse()
+            .expect("formatted a f32 literal"),
+        Err(e) => panic!("hexf32! failed: {}", e),
     }
 }
 
-proc_macro_expr_impl! {
-    /// Support function for `hexf64!` macro. Do not use directly.
-    #[doc(hidden)]
-    pub fn hexf64_impl(input: &str) -> String {
-        let lit = syn::parse_str::<syn::LitStr>(input).expect("hexf64! requires a single string literal");
-        match hexf_parse::parse_hexf64(&lit.value(), true) {
-            Ok(v) => format!("{:?}f64", v), // should keep the sign even for -0.0
-            Err(e) => panic!("hexf64! failed: {}", e),
-        }
+/// Expands to a `f64` value with given hexadecimal representation.
+///
+/// # Example
+///
+/// ```rust
+/// # use hexf::hexf64; fn main() {
+/// assert_eq!(hexf64!("0x1.999999999999ap-4"), 0.1f64);
+/// # }
+/// ```
+#[proc_macro]
+pub fn hexf64(input: TokenStream) -> TokenStream {
+    let lit = syn::parse_macro_input!(input as syn::LitStr);
+    match hexf_parse::parse_hexf64(&lit.value(), true) {
+        Ok(v) => format!("{:?}f64", v) // should keep the sign even for -0.0
+            .parse()
+            .expect("formatted a f64 literal"),
+        Err(e) => panic!("hexf64! failed: {}", e),
     }
 }
-

--- a/parse/Cargo.toml
+++ b/parse/Cargo.toml
@@ -8,4 +8,4 @@ homepage = "https://github.com/lifthrasiir/hexf"
 documentation = "https://docs.rs/hexf-parse/"
 repository = "https://github.com/lifthrasiir/hexf"
 license = "CC0-1.0"
-
+edition = "2018"

--- a/parse/Cargo.toml
+++ b/parse/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hexf-parse"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Kang Seonghoon <public+rust@mearie.org>"]
 
 description = "Parses hexadecimal floats (see also hexf)"

--- a/parse/src/lib.rs
+++ b/parse/src/lib.rs
@@ -17,7 +17,7 @@
 //!
 //! The error is reported via an opaque `ParseHexfError` type.
 
-use std::{fmt, str, f32, f64, isize};
+use std::{f32, f64, fmt, isize, str};
 
 /// An opaque error type from `parse_hexf32` and `parse_hexf64`.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -32,9 +32,15 @@ enum ParseHexfErrorKind {
     Inexact,
 }
 
-const EMPTY: ParseHexfError = ParseHexfError { kind: ParseHexfErrorKind::Empty };
-const INVALID: ParseHexfError = ParseHexfError { kind: ParseHexfErrorKind::Invalid };
-const INEXACT: ParseHexfError = ParseHexfError { kind: ParseHexfErrorKind::Inexact };
+const EMPTY: ParseHexfError = ParseHexfError {
+    kind: ParseHexfErrorKind::Empty,
+};
+const INVALID: ParseHexfError = ParseHexfError {
+    kind: ParseHexfErrorKind::Invalid,
+};
+const INEXACT: ParseHexfError = ParseHexfError {
+    kind: ParseHexfErrorKind::Inexact,
+};
 
 impl ParseHexfError {
     fn text(&self) -> &'static str {
@@ -47,11 +53,15 @@ impl ParseHexfError {
 }
 
 impl fmt::Display for ParseHexfError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { fmt::Display::fmt(self.text(), f) }
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Display::fmt(self.text(), f)
+    }
 }
 
 impl std::error::Error for ParseHexfError {
-    fn description(&self) -> &'static str { self.text() }
+    fn description(&self) -> &'static str {
+        self.text()
+    }
 }
 
 fn parse(s: &[u8], allow_underscore: bool) -> Result<(bool, u64, isize), ParseHexfError> {
@@ -74,13 +84,13 @@ fn parse(s: &[u8], allow_underscore: bool) -> Result<(bool, u64, isize), ParseHe
     let mut digit_seen = false;
     loop {
         let (s_, digit) = match s.split_first() {
-            Some((&c @ b'0'...b'9', s)) => (s, c - b'0'),
-            Some((&c @ b'a'...b'f', s)) => (s, c - b'a' + 10),
-            Some((&c @ b'A'...b'F', s)) => (s, c - b'A' + 10),
+            Some((&c @ b'0'..=b'9', s)) => (s, c - b'0'),
+            Some((&c @ b'a'..=b'f', s)) => (s, c - b'a' + 10),
+            Some((&c @ b'A'..=b'F', s)) => (s, c - b'A' + 10),
             Some((&b'_', s_)) if allow_underscore && digit_seen => {
                 s = s_;
                 continue;
-            },
+            }
             _ => break,
         };
 
@@ -108,13 +118,13 @@ fn parse(s: &[u8], allow_underscore: bool) -> Result<(bool, u64, isize), ParseHe
     let mut frac_digit_seen = false;
     loop {
         let (s_, digit) = match s.split_first() {
-            Some((&c @ b'0'...b'9', s)) => (s, c - b'0'),
-            Some((&c @ b'a'...b'f', s)) => (s, c - b'a' + 10),
-            Some((&c @ b'A'...b'F', s)) => (s, c - b'A' + 10),
+            Some((&c @ b'0'..=b'9', s)) => (s, c - b'0'),
+            Some((&c @ b'a'..=b'f', s)) => (s, c - b'a' + 10),
+            Some((&c @ b'A'..=b'F', s)) => (s, c - b'A' + 10),
             Some((&b'_', s_)) if allow_underscore && frac_digit_seen => {
                 s = s_;
                 continue;
-            },
+            }
             _ => break,
         };
 
@@ -163,11 +173,11 @@ fn parse(s: &[u8], allow_underscore: bool) -> Result<(bool, u64, isize), ParseHe
     let mut exponent = 0isize; // this is suboptimal but also practical, see below
     loop {
         let (s_, digit) = match s.split_first() {
-            Some((&c @ b'0'...b'9', s)) => (s, c - b'0'),
+            Some((&c @ b'0'..=b'9', s)) => (s, c - b'0'),
             Some((&b'_', s_)) if allow_underscore => {
                 s = s_;
                 continue;
-            },
+            }
             None if digit_seen => break,
             // no more bytes expected, and at least one exponent digit should be present
             _ => return Err(INVALID),
@@ -178,8 +188,10 @@ fn parse(s: &[u8], allow_underscore: bool) -> Result<(bool, u64, isize), ParseHe
 
         // if we have no non-zero digits at this point, ignore the exponent :-)
         if acc != 0 {
-            exponent = exponent.checked_mul(10).and_then(|v| v.checked_add(digit as isize))
-                                               .ok_or(INEXACT)?;
+            exponent = exponent
+                .checked_mul(10)
+                .and_then(|v| v.checked_add(digit as isize))
+                .ok_or(INEXACT)?;
         }
     }
     if negative_exponent {
@@ -193,8 +205,10 @@ fn parse(s: &[u8], allow_underscore: bool) -> Result<(bool, u64, isize), ParseHe
         // the exponent should be biased by (nfracs * 4) to match with the mantissa read.
         // we still miss valid inputs like `0.0000...0001pX` where the input is filling
         // at least 1/4 of the total addressable memory, but I dare not handle them!
-        let exponent = nfracs.checked_mul(4).and_then(|v| exponent.checked_sub(v))
-                                            .ok_or(INEXACT)?;
+        let exponent = nfracs
+            .checked_mul(4)
+            .and_then(|v| exponent.checked_sub(v))
+            .ok_or(INEXACT)?;
         Ok((negative, acc, exponent))
     }
 }
@@ -216,16 +230,37 @@ fn test_parse() {
     assert_eq!(parse(b"0x.P1", false), Err(INVALID));
     assert_eq!(parse(b"0x0P1", false), Err(INVALID));
     assert_eq!(parse(b"0x0.p999999999", false), Ok((false, 0, 0)));
-    assert_eq!(parse(b"0x0.p99999999999999999999999999999", false), Ok((false, 0, 0)));
-    assert_eq!(parse(b"0x0.p-99999999999999999999999999999", false), Ok((false, 0, 0)));
-    assert_eq!(parse(b"0x1.p99999999999999999999999999999", false), Err(INEXACT));
-    assert_eq!(parse(b"0x1.p-99999999999999999999999999999", false), Err(INEXACT));
-    assert_eq!(parse(b"0x4.00000000000000000000p55", false), Ok((false, 4, 55)));
-    assert_eq!(parse(b"0x4.00001000000000000000p55", false), Ok((false, 0x400001, 55 - 20)));
+    assert_eq!(
+        parse(b"0x0.p99999999999999999999999999999", false),
+        Ok((false, 0, 0))
+    );
+    assert_eq!(
+        parse(b"0x0.p-99999999999999999999999999999", false),
+        Ok((false, 0, 0))
+    );
+    assert_eq!(
+        parse(b"0x1.p99999999999999999999999999999", false),
+        Err(INEXACT)
+    );
+    assert_eq!(
+        parse(b"0x1.p-99999999999999999999999999999", false),
+        Err(INEXACT)
+    );
+    assert_eq!(
+        parse(b"0x4.00000000000000000000p55", false),
+        Ok((false, 4, 55))
+    );
+    assert_eq!(
+        parse(b"0x4.00001000000000000000p55", false),
+        Ok((false, 0x400001, 55 - 20))
+    );
     assert_eq!(parse(b"0x4.00000000000000000001p55", false), Err(INEXACT));
 
     // underscore insertion
-    assert_eq!(parse(b"-0x3____.1_4___p+___5___", true), Ok((true, 0x314, 5 - 8)));
+    assert_eq!(
+        parse(b"-0x3____.1_4___p+___5___", true),
+        Ok((true, 0x314, 5 - 8))
+    );
     assert_eq!(parse(b"-_0x3.14p+5", true), Err(INVALID));
     assert_eq!(parse(b"_0x3.14p+5", true), Err(INVALID));
     assert_eq!(parse(b"0x_3.14p+5", true), Err(INVALID));
@@ -237,7 +272,7 @@ fn test_parse() {
 }
 
 macro_rules! define_convert {
-    ($name:ident => $f:ident) => (
+    ($name:ident => $f:ident) => {
         fn $name(negative: bool, mantissa: u64, exponent: isize) -> Result<$f, ParseHexfError> {
             // guard the exponent with the definitely safe range (we will exactly bound it later)
             if exponent < -0xffff || exponent > 0xffff {
@@ -274,14 +309,16 @@ macro_rules! define_convert {
 
             if mantissa >> mantissasize == 0 {
                 let mut mantissa = mantissa as $f;
-                if negative { mantissa = -mantissa; }
+                if negative {
+                    mantissa = -mantissa;
+                }
                 // yes, powi somehow does not work!
                 Ok(mantissa * (2.0 as $f).powf(exponent as $f))
             } else {
                 Err(INEXACT)
             }
         }
-    )
+    };
 }
 
 define_convert!(convert_hexf32 => f32);
@@ -302,10 +339,22 @@ fn test_convert_hexf32() {
     assert_eq!(convert_hexf32(true, 0, 0).unwrap().signum(), -1.0);
 
     // normal truncation
-    assert_eq!(convert_hexf32(false, 0x0000_0000_00ff_ffff, 0), Ok(16777215.0));
-    assert_eq!(convert_hexf32(false, 0x0000_0000_01ff_ffff, 0), Err(INEXACT));
-    assert_eq!(convert_hexf32(false, 0xffff_ff00_0000_0000, -40), Ok(16777215.0));
-    assert_eq!(convert_hexf32(false, 0xffff_ff80_0000_0000, -40), Err(INEXACT));
+    assert_eq!(
+        convert_hexf32(false, 0x0000_0000_00ff_ffff, 0),
+        Ok(16777215.0)
+    );
+    assert_eq!(
+        convert_hexf32(false, 0x0000_0000_01ff_ffff, 0),
+        Err(INEXACT)
+    );
+    assert_eq!(
+        convert_hexf32(false, 0xffff_ff00_0000_0000, -40),
+        Ok(16777215.0)
+    );
+    assert_eq!(
+        convert_hexf32(false, 0xffff_ff80_0000_0000, -40),
+        Err(INEXACT)
+    );
 
     // denormal truncation
     assert!(convert_hexf32(false, 0x0000_0000_007f_ffff, -149).is_ok());
@@ -325,13 +374,34 @@ fn test_convert_hexf32() {
     assert!(convert_hexf32(false, 0x8000_0000_0000_0000, -213).is_err());
 
     // maximum
-    assert_eq!(convert_hexf32(false, 0x0000_0000_00ff_ffff, 104), Ok(f32::MAX));
-    assert_eq!(convert_hexf32(false, 0x0000_0000_01ff_ffff, 104), Err(INEXACT));
-    assert_eq!(convert_hexf32(false, 0x0000_0000_01ff_fffe, 104), Err(INEXACT));
-    assert_eq!(convert_hexf32(false, 0x0000_0000_0000_0001, 128), Err(INEXACT));
-    assert_eq!(convert_hexf32(false, 0x8000_0000_0000_0000, 65), Err(INEXACT));
-    assert_eq!(convert_hexf32(false, 0xffff_ff00_0000_0000, 64), Ok(f32::MAX));
-    assert_eq!(convert_hexf32(false, 0xffff_ff80_0000_0000, 64), Err(INEXACT));
+    assert_eq!(
+        convert_hexf32(false, 0x0000_0000_00ff_ffff, 104),
+        Ok(f32::MAX)
+    );
+    assert_eq!(
+        convert_hexf32(false, 0x0000_0000_01ff_ffff, 104),
+        Err(INEXACT)
+    );
+    assert_eq!(
+        convert_hexf32(false, 0x0000_0000_01ff_fffe, 104),
+        Err(INEXACT)
+    );
+    assert_eq!(
+        convert_hexf32(false, 0x0000_0000_0000_0001, 128),
+        Err(INEXACT)
+    );
+    assert_eq!(
+        convert_hexf32(false, 0x8000_0000_0000_0000, 65),
+        Err(INEXACT)
+    );
+    assert_eq!(
+        convert_hexf32(false, 0xffff_ff00_0000_0000, 64),
+        Ok(f32::MAX)
+    );
+    assert_eq!(
+        convert_hexf32(false, 0xffff_ff80_0000_0000, 64),
+        Err(INEXACT)
+    );
 }
 
 #[test]
@@ -349,10 +419,22 @@ fn test_convert_hexf64() {
     assert_eq!(convert_hexf64(true, 0, 0).unwrap().signum(), -1.0);
 
     // normal truncation
-    assert_eq!(convert_hexf64(false, 0x001f_ffff_ffff_ffff, 0), Ok(9007199254740991.0));
-    assert_eq!(convert_hexf64(false, 0x003f_ffff_ffff_ffff, 0), Err(INEXACT));
-    assert_eq!(convert_hexf64(false, 0xffff_ffff_ffff_f800, -11), Ok(9007199254740991.0));
-    assert_eq!(convert_hexf64(false, 0xffff_ffff_ffff_fc00, -11), Err(INEXACT));
+    assert_eq!(
+        convert_hexf64(false, 0x001f_ffff_ffff_ffff, 0),
+        Ok(9007199254740991.0)
+    );
+    assert_eq!(
+        convert_hexf64(false, 0x003f_ffff_ffff_ffff, 0),
+        Err(INEXACT)
+    );
+    assert_eq!(
+        convert_hexf64(false, 0xffff_ffff_ffff_f800, -11),
+        Ok(9007199254740991.0)
+    );
+    assert_eq!(
+        convert_hexf64(false, 0xffff_ffff_ffff_fc00, -11),
+        Err(INEXACT)
+    );
 
     // denormal truncation
     assert!(convert_hexf64(false, 0x000f_ffff_ffff_ffff, -1074).is_ok());
@@ -372,13 +454,34 @@ fn test_convert_hexf64() {
     assert!(convert_hexf64(false, 0x8000_0000_0000_0000, -1138).is_err());
 
     // maximum
-    assert_eq!(convert_hexf64(false, 0x001f_ffff_ffff_ffff, 971), Ok(f64::MAX));
-    assert_eq!(convert_hexf64(false, 0x003f_ffff_ffff_ffff, 971), Err(INEXACT));
-    assert_eq!(convert_hexf64(false, 0x003f_ffff_ffff_fffe, 971), Err(INEXACT));
-    assert_eq!(convert_hexf32(false, 0x0000_0000_0000_0001, 1024), Err(INEXACT));
-    assert_eq!(convert_hexf32(false, 0x8000_0000_0000_0000, 961), Err(INEXACT));
-    assert_eq!(convert_hexf64(false, 0xffff_ffff_ffff_f800, 960), Ok(f64::MAX));
-    assert_eq!(convert_hexf64(false, 0xffff_ffff_ffff_fc00, 960), Err(INEXACT));
+    assert_eq!(
+        convert_hexf64(false, 0x001f_ffff_ffff_ffff, 971),
+        Ok(f64::MAX)
+    );
+    assert_eq!(
+        convert_hexf64(false, 0x003f_ffff_ffff_ffff, 971),
+        Err(INEXACT)
+    );
+    assert_eq!(
+        convert_hexf64(false, 0x003f_ffff_ffff_fffe, 971),
+        Err(INEXACT)
+    );
+    assert_eq!(
+        convert_hexf32(false, 0x0000_0000_0000_0001, 1024),
+        Err(INEXACT)
+    );
+    assert_eq!(
+        convert_hexf32(false, 0x8000_0000_0000_0000, 961),
+        Err(INEXACT)
+    );
+    assert_eq!(
+        convert_hexf64(false, 0xffff_ffff_ffff_f800, 960),
+        Ok(f64::MAX)
+    );
+    assert_eq!(
+        convert_hexf64(false, 0xffff_ffff_ffff_fc00, 960),
+        Err(INEXACT)
+    );
 }
 
 /// Tries to parse a hexadecimal float literal to `f32`.
@@ -394,4 +497,3 @@ pub fn parse_hexf64(s: &str, allow_underscore: bool) -> Result<f64, ParseHexfErr
     let (negative, mantissa, exponent) = parse(s.as_bytes(), allow_underscore)?;
     convert_hexf64(negative, mantissa, exponent)
 }
-

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,36 +9,5 @@
 //! # }
 //! ```
 
-#[macro_use] extern crate proc_macro_hack;
-#[macro_use] #[allow(unused_imports)] extern crate hexf_impl;
-extern crate hexf_parse;
-
-pub use hexf_parse::{ParseHexfError, parse_hexf32, parse_hexf64};
-#[doc(hidden)] pub use hexf_impl::*;
-
-proc_macro_expr_decl! {
-    /// Expands to a `f32` value with given hexadecimal representation.
-    ///
-    /// # Example
-    ///
-    /// ```rust
-    /// # #[macro_use] extern crate hexf; fn main() {
-    /// assert_eq!(hexf32!("0x1.99999ap-4"), 0.1f32);
-    /// # }
-    /// ```
-    hexf32! => hexf32_impl
-}
-
-proc_macro_expr_decl! {
-    /// Expands to a `f64` value with given hexadecimal representation.
-    ///
-    /// # Example
-    ///
-    /// ```rust
-    /// # #[macro_use] extern crate hexf; fn main() {
-    /// assert_eq!(hexf64!("0x1.999999999999ap-4"), 0.1f64);
-    /// # }
-    /// ```
-    hexf64! => hexf64_impl
-}
-
+pub use hexf_impl::{hexf32, hexf64};
+pub use hexf_parse::{parse_hexf32, parse_hexf64, ParseHexfError};

--- a/tests/example.rs
+++ b/tests/example.rs
@@ -1,4 +1,4 @@
-#[macro_use] extern crate hexf;
+use hexf::{hexf32, hexf64};
 
 use std::f64;
 


### PR DESCRIPTION
Hi! So, first off, I apologize for sending such a big diff at once. I'm happy to break this down into smaller PRs if you would prefer.

Thanks for making a small useful crate that has needed essentially no maintenance. About two months ago, changes finally landed in rust stable that support proc macros in the expression position, which obviates `proc_macro_hack` - that crate has noted its no longer necessary in [its readme](https://github.com/dtolnay/proc-macro-hack/blob/master/README.md).

This PR gets rid of all `proc_macro_hack` machinery. It also updates the crates to the rust 2018 edition, which permits importing macros via ordinary `use hexf::hexf32;` statements rather than `#[macro_use] extern crate hexf;`. I stumbled upon this modernization project because a new rustacean colleague wasn't aware of the old macro_use syntax, so I think this update will help usability. In order to use these new features, the minimum rust version has been updated to 1.45.0. I think I got all of the spots this is mentioned in docs and CI.

Finally, we bump to the latest `syn` dependency. This will help users keep their dependency trees slim, since its very common to depend on a `1.0.x` series `syn` these days.

Inadvertently, my editor applied `rustfmt` to all of the files I edited (which ended up being all of them). This does make the diff a bit bigger but doesn't seem harmful to me. This whole patch took me about 20 minutes to write so if you'd like me to redo it without the rustfmt changes I'm amenable.