### PR TITLE
Report errors via syn compile_error mechanism

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,5 +19,5 @@ proc-macro = true
 
 [dependencies]
 hexf-parse = { version = "0.2.0", path = "parse/" }
-syn = "1.0.41"
+syn = { version = "1.0.41", default-features = false, features = ["parsing", "proc-macro"] }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,7 +27,11 @@ pub fn hexf32(input: TokenStream) -> TokenStream {
         Ok(v) => format!("{:?}f32", v) // should keep the sign even for -0.0
             .parse()
             .expect("formatted a f32 literal"),
-        Err(e) => panic!("hexf32! failed: {}", e),
+        Err(e) => {
+            syn::Error::new(lit.span(), format!("hexf32! failed: {}", e))
+                .to_compile_error()
+                .into()
+        },
     }
 }
 
@@ -47,6 +51,10 @@ pub fn hexf64(input: TokenStream) -> TokenStream {
         Ok(v) => format!("{:?}f64", v) // should keep the sign even for -0.0
             .parse()
             .expect("formatted a f64 literal"),
-        Err(e) => panic!("hexf64! failed: {}", e),
+        Err(e) => {
+            syn::Error::new(lit.span(), format!("hexf64! failed: {}", e))
+                .to_compile_error()
+                .into()
+        },
     }
 }


### PR DESCRIPTION
Use syn to generate compile_error messages in the event of parser failure to avoid proc_macro panic messages.

Only enable syn features that are used by the crate.