### PR TITLE
Implement basic fuzzing

### DIFF
--- a/fuzz/.gitignore
+++ b/fuzz/.gitignore
@@ -1,0 +1,4 @@
+
+target
+corpus
+artifacts

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,0 +1,28 @@
+
+[package]
+name = "hexf-fuzz"
+version = "0.0.0"
+publish = false
+edition = "2018"
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.4"
+arbitrary = { version = "1", features = ["derive"] }
+libc = "0.2"
+errno = "0.2"
+
+[dependencies.hexf-parse]
+path = "../parse/"
+
+# Prevent this from interfering with workspaces
+[workspace]
+members = ["."]
+
+[[bin]]
+name = "hexf_parse"
+path = "fuzz_targets/hexf_parse.rs"
+test = false
+doc = false

--- a/fuzz/fuzz_targets/hexf_parse.rs
+++ b/fuzz/fuzz_targets/hexf_parse.rs
@@ -1,0 +1,78 @@
+#![no_main]
+
+use std::{ffi::CString, ptr};
+
+use errno::{errno, set_errno, Errno};
+use libc::strtod;
+use libfuzzer_sys::{arbitrary::Arbitrary, fuzz_target};
+
+use hexf_parse::{parse_hexf32, parse_hexf64};
+
+#[derive(Debug, Arbitrary)]
+enum TargetType {
+    F32,
+    F64,
+}
+
+// IMPORTANT: For the verification with strtof/d to work properly, your locale (LC_ALL) should be set C.UTF-8.
+//            Otherwise strtof/d will use your locale's decimal separator.
+
+macro_rules! verify_with_strto_fn {
+    ($target_name:ident, $strto_fn:ident, $string_to_parse:ident, $result:ident) => {
+        if $string_to_parse.contains("p") || $string_to_parse.contains("P") {
+            if let Ok(c_string) = CString::new($string_to_parse.replace('_', "")) {
+                unsafe {
+                    // strtod will write a *mut c_char to the character past the last interpreted character in here
+                    let mut end_ptr = ptr::null_mut();
+
+                    let strto_fn_result = $strto_fn(c_string.as_ptr(), &mut end_ptr);
+
+                    // See https://en.cppreference.com/w/c/string/byte/strtof
+                    // for a description of the behavior of strtof/d functions
+
+                    let strto_fn_errno = errno();
+                    if strto_fn_errno.0 != 0 {
+                        assert!(
+                            $result.is_err(),
+                            concat!(stringify!($target_name), " succeeded, but strtod failed with `{}`"),
+                            strto_fn_errno
+                        );
+                        set_errno(Errno(0))
+                    } else if *end_ptr != 0 {
+                        assert!(
+                            $result.is_err(),
+                            concat!(stringify!($target_name), " succeeded, but strtod only parsed up to byte {} of {}"),
+                            end_ptr.offset_from(c_string.as_ptr()),
+                            c_string.as_bytes().len() - 1
+                        );
+                    } else if strto_fn_result.is_infinite() {
+                        assert!(
+                            $result.is_err(),
+                            concat!(stringify!($target_name), " succeeded, but strtod reported an overflow / underflow"),
+                        );
+                    } else if let Ok(value) = $result {
+                        assert_eq!(value, strto_fn_result);
+                    }
+                }
+            }
+        }
+    };
+}
+
+fuzz_target!(|data: (TargetType, bool, String)| {
+    let (target_type, allow_underscore, string_to_parse) = data;
+
+    match target_type {
+        TargetType::F32 => {
+            let _result = parse_hexf32(&string_to_parse, allow_underscore);
+
+            // TODO: add verification with strtof for parse_hexf32 once the libc crate has strtof
+            // verify_with_strto_fn!(parse_hexf32, strtof, string_to_parse, result);
+        }
+        TargetType::F64 => {
+            let result = parse_hexf64(&string_to_parse, allow_underscore);
+
+            verify_with_strto_fn!(parse_hexf64, strtod, string_to_parse, result);
+        }
+    }
+});


### PR DESCRIPTION
Check that no panics occur and compare to `libc::strtod` for reference
in the case of parse_hexf64. `strtof` is not yet avaiable in the libc
crate, so parse_hexf32 is only being checked for panics at the moment.