### PR TITLE
Reduce MSRV to 1.43

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: rust
 sudo: false
 rust:
-  - 1.45.0
+  - 1.43.0
   - stable
   - beta
   - nightly

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 [docsrs-image]: https://docs.rs/hexf/badge.svg
 [docsrs]: https://docs.rs/hexf/
 
-Hexadecimal float support for Rust 1.45 or later. (For earlier versions, try `0.1.0`)
+Hexadecimal float support for Rust 1.43 or later. (For earlier versions, try `0.1.0`)
 
 ```rust
 use hexf::hexf64;
@@ -105,4 +105,3 @@ See [rust-lang/rust#1433][issue-1433] for the more context.
 
 [dec2flt-paper]: http://citeseerx.ist.psu.edu/viewdoc/summary?doi=10.1.1.45.4152
 [issue-1433]: https://github.com/rust-lang/rust/issues/1433#issuecomment-288184018
-

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-//! Hexadecimal float support for Rust 1.45 or later.
+//! Hexadecimal float support for Rust 1.43 or later.
 //!
 //! ```rust
 //! use hexf::{hexf32, hexf64};


### PR DESCRIPTION
The current code compiles with Rust 1.43. As such, reducing the
advertised MSRV will allow more people to use it.

Fixes #18.