### PR TITLE
use libm::exp2

### DIFF
--- a/parse/Cargo.toml
+++ b/parse/Cargo.toml
@@ -9,3 +9,6 @@ documentation = "https://docs.rs/hexf-parse/"
 repository = "https://github.com/lifthrasiir/hexf"
 license = "CC0-1.0"
 edition = "2018"
+
+[dependencies]
+libm = "0.2.2"

--- a/parse/src/lib.rs
+++ b/parse/src/lib.rs
@@ -340,7 +340,7 @@ macro_rules! define_convert {
                     mantissa = -mantissa;
                 }
                 // yes, powi somehow does not work!
-                Ok(mantissa * (2.0 as $f).powf(exponent as $f))
+                Ok(mantissa * libm::exp2(exponent as f64) as $f)
             } else {
                 Err(INEXACT)
             }


### PR DESCRIPTION
We have `hexf` as a transitive dependency `wgpu-hal -> naga -> hexf-parse` in Deno. Unfortuanetly this pulls in a GLIBC dependency on `expf2` because LLVM optimizes `2.0.powf(exp)` to `exp2f`. `exp2f` is not present in glibc 2.23 and hence Deno is not able to run on Ubuntu 16, Amazon Linux, etc. 
Ref https://github.com/denoland/deno/issues/13516#issuecomment-1057534690

This patch introduces `libm::exp2` to avoid the above issue. 
