### PR TITLE
Support `no_std` in hexf-parse.

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -46,4 +46,4 @@ jobs:
           rustup target add ${{ matrix.target }} --toolchain stable
           rustup override set stable
       - name: Clippy
-        run: cargo clippy --all --target ${{ matrix.target }}
+        run: cargo clippy --manifest-path parse/Cargo.toml --target ${{ matrix.target }} --no-default-features

--- a/parse/Cargo.toml
+++ b/parse/Cargo.toml
@@ -12,3 +12,7 @@ edition = "2018"
 
 [dependencies]
 libm = "0.2.2"
+
+[features]
+default = ["std"]
+std = []

--- a/parse/src/lib.rs
+++ b/parse/src/lib.rs
@@ -59,6 +59,14 @@ impl fmt::Display for ParseHexfError {
     }
 }
 
+#[cfg(feature = "std")]
+impl std::error::Error for ParseHexfError {
+    fn description(&self) -> &'static str {
+        self.text()
+    }
+}
+
+#[cfg(not(feature = "std"))]
 impl core::error::Error for ParseHexfError {
     fn description(&self) -> &'static str {
         self.text()

--- a/parse/src/lib.rs
+++ b/parse/src/lib.rs
@@ -59,8 +59,7 @@ impl fmt::Display for ParseHexfError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for ParseHexfError {
+impl core::error::Error for ParseHexfError {
     fn description(&self) -> &'static str {
         self.text()
     }

--- a/parse/src/lib.rs
+++ b/parse/src/lib.rs
@@ -17,8 +17,7 @@
 //!
 //! The error is reported via an opaque `ParseHexfError` type.
 
-#![no_std]
-
+#![cfg_attr(not(feature = "std"), no_std)]
 use core::{f32, f64, fmt, isize, str};
 
 /// An opaque error type from `parse_hexf32` and `parse_hexf64`.
@@ -60,7 +59,8 @@ impl fmt::Display for ParseHexfError {
     }
 }
 
-impl core::error::Error for ParseHexfError {
+#[cfg(feature = "std")]
+impl std::error::Error for ParseHexfError {
     fn description(&self) -> &'static str {
         self.text()
     }


### PR DESCRIPTION
Support `no_std` in hexf-parse, by adding a "std" feature, enabled by default, and putting the impl of `std::error::Error` behind it.
