### PR TITLE
Replace syn with handwritten TokenStream parser/output

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,5 +19,4 @@ proc-macro = true
 
 [dependencies]
 hexf-parse = { version = "0.2.1", path = "parse/" }
-syn = { version = "1.0.41", default-features = false, features = ["parsing", "proc-macro"] }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,10 @@
 //! # }
 //! ```
 
-use proc_macro::{Delimiter, Group, Ident, Literal, Punct, Spacing, Span, TokenStream, TokenTree};
+mod tokens;
+
+use proc_macro::{Literal, TokenStream, TokenTree};
+use tokens::{compile_error_stream, parse_stream};
 
 /// Expands to a `f32` value with given hexadecimal representation.
 ///
@@ -43,98 +46,4 @@ pub fn hexf64(input: TokenStream) -> TokenStream {
         Ok(v) => TokenTree::Literal(Literal::f64_suffixed(v)).into(),
         Err(e) => compile_error_stream(&format!("hexf64! failed: {}", e), span),
     })
-}
-
-const EXPECTED_STRING_LITERAL: &str = "expected string literal";
-
-fn parse_stream<F>(input: TokenStream, process_literal: F) -> TokenStream
-where
-    F: FnOnce(&str, Span) -> TokenStream,
-{
-    let literal = match get_literal(input) {
-        Ok(lit) => lit,
-        Err(tokens) => return tokens,
-    };
-
-    match extract_string_value(&format!("{}", literal)) {
-        Some(s) => process_literal(s, literal.span()),
-        None => compile_error_stream(EXPECTED_STRING_LITERAL, literal.span()),
-    }
-}
-
-fn get_literal(input: TokenStream) -> Result<Literal, TokenStream> {
-    let mut trees = input.into_iter();
-    let tree = trees.next().ok_or_else(|| {
-        compile_error_stream(
-            "unexpected end of input, expected string literal",
-            Span::call_site(),
-        )
-    })?;
-
-    if let Some(next_tree) = trees.next() {
-        return Err(compile_error_stream("unexpected token", next_tree.span()));
-    }
-
-    match tree {
-        TokenTree::Literal(literal) => Ok(literal),
-        _ => Err(compile_error_stream(EXPECTED_STRING_LITERAL, tree.span())),
-    }
-}
-
-fn extract_string_value(literal: &str) -> Option<&str> {
-    if literal.starts_with('"') {
-        if literal.len() >= 2 && literal.ends_with('"') {
-            // For simplicity, we do not handle any escape sequences. Given the
-            // usage of these macros, they would be of questionable utility.
-            Some(&literal[1..(literal.len() - 1)])
-        } else {
-            None
-        }
-    } else if literal.starts_with('r') {
-        let mut forward = literal.char_indices().skip(1);
-        let mut reverse = literal.char_indices().rev();
-        loop {
-            let (forward_pos, forward_char) = forward.next()?;
-            let (reverse_pos, reverse_char) = reverse.next()?;
-            if forward_char != reverse_char || forward_pos >= reverse_pos {
-                return None;
-            }
-
-            if forward_char == '"' {
-                return Some(&literal[(forward_pos + 1)..reverse_pos]);
-            }
-
-            if forward_char != '#' {
-                return None;
-            }
-        }
-    } else {
-        None
-    }
-}
-
-fn compile_error_stream(message: &str, span: Span) -> TokenStream {
-    fn with_span(mut token_tree: TokenTree, span: Span) -> TokenTree {
-        token_tree.set_span(span);
-        token_tree
-    }
-
-    let message_token = with_span(TokenTree::Literal(Literal::string(message)), span);
-
-    let mut tokens = TokenStream::new();
-    tokens.extend([
-        with_span(TokenTree::Punct(Punct::new(':', Spacing::Joint)), span),
-        with_span(TokenTree::Punct(Punct::new(':', Spacing::Alone)), span),
-        TokenTree::Ident(Ident::new("core", span)),
-        with_span(TokenTree::Punct(Punct::new(':', Spacing::Joint)), span),
-        with_span(TokenTree::Punct(Punct::new(':', Spacing::Alone)), span),
-        TokenTree::Ident(Ident::new("compile_error", span)),
-        with_span(TokenTree::Punct(Punct::new('!', Spacing::Alone)), span),
-        with_span(
-            TokenTree::Group(Group::new(Delimiter::Brace, message_token.into())),
-            span,
-        ),
-    ]);
-
-    tokens
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@
 //! # }
 //! ```
 
-use proc_macro::TokenStream;
+use proc_macro::{Delimiter, Group, Ident, Literal, Punct, Spacing, Span, TokenStream, TokenTree};
 
 /// Expands to a `f32` value with given hexadecimal representation.
 ///
@@ -22,15 +22,10 @@ use proc_macro::TokenStream;
 /// ```
 #[proc_macro]
 pub fn hexf32(input: TokenStream) -> TokenStream {
-    let lit = syn::parse_macro_input!(input as syn::LitStr);
-    match hexf_parse::parse_hexf32(&lit.value(), true) {
-        Ok(v) => format!("{:?}f32", v) // should keep the sign even for -0.0
-            .parse()
-            .expect("formatted a f32 literal"),
-        Err(e) => syn::Error::new(lit.span(), format!("hexf32! failed: {}", e))
-            .to_compile_error()
-            .into(),
-    }
+    parse_stream(input, |s, span| match hexf_parse::parse_hexf32(s, true) {
+        Ok(v) => TokenTree::Literal(Literal::f32_suffixed(v)).into(),
+        Err(e) => compile_error_stream(&format!("hexf32! failed: {}", e), span),
+    })
 }
 
 /// Expands to a `f64` value with given hexadecimal representation.
@@ -44,13 +39,102 @@ pub fn hexf32(input: TokenStream) -> TokenStream {
 /// ```
 #[proc_macro]
 pub fn hexf64(input: TokenStream) -> TokenStream {
-    let lit = syn::parse_macro_input!(input as syn::LitStr);
-    match hexf_parse::parse_hexf64(&lit.value(), true) {
-        Ok(v) => format!("{:?}f64", v) // should keep the sign even for -0.0
-            .parse()
-            .expect("formatted a f64 literal"),
-        Err(e) => syn::Error::new(lit.span(), format!("hexf64! failed: {}", e))
-            .to_compile_error()
-            .into(),
+    parse_stream(input, |s, span| match hexf_parse::parse_hexf64(s, true) {
+        Ok(v) => TokenTree::Literal(Literal::f64_suffixed(v)).into(),
+        Err(e) => compile_error_stream(&format!("hexf64! failed: {}", e), span),
+    })
+}
+
+const EXPECTED_STRING_LITERAL: &str = "expected string literal";
+
+fn parse_stream<F>(input: TokenStream, process_literal: F) -> TokenStream
+where
+    F: FnOnce(&str, Span) -> TokenStream,
+{
+    let literal = match get_literal(input) {
+        Ok(lit) => lit,
+        Err(tokens) => return tokens,
+    };
+
+    match extract_string_value(&format!("{}", literal)) {
+        Some(s) => process_literal(s, literal.span()),
+        None => compile_error_stream(EXPECTED_STRING_LITERAL, literal.span()),
     }
+}
+
+fn get_literal(input: TokenStream) -> Result<Literal, TokenStream> {
+    let mut trees = input.into_iter();
+    let tree = trees.next().ok_or_else(|| {
+        compile_error_stream(
+            "unexpected end of input, expected string literal",
+            Span::call_site(),
+        )
+    })?;
+
+    if let Some(next_tree) = trees.next() {
+        return Err(compile_error_stream("unexpected token", next_tree.span()));
+    }
+
+    match tree {
+        TokenTree::Literal(literal) => Ok(literal),
+        _ => Err(compile_error_stream(EXPECTED_STRING_LITERAL, tree.span())),
+    }
+}
+
+fn extract_string_value(literal: &str) -> Option<&str> {
+    if literal.starts_with('"') {
+        if literal.len() >= 2 && literal.ends_with('"') {
+            // For simplicity, we do not handle any escape sequences. Given the
+            // usage of these macros, they would be of questionable utility.
+            Some(&literal[1..(literal.len() - 1)])
+        } else {
+            None
+        }
+    } else if literal.starts_with('r') {
+        let mut forward = literal.char_indices().skip(1);
+        let mut reverse = literal.char_indices().rev();
+        loop {
+            let (forward_pos, forward_char) = forward.next()?;
+            let (reverse_pos, reverse_char) = reverse.next()?;
+            if forward_char != reverse_char || forward_pos >= reverse_pos {
+                return None;
+            }
+
+            if forward_char == '"' {
+                return Some(&literal[(forward_pos + 1)..reverse_pos]);
+            }
+
+            if forward_char != '#' {
+                return None;
+            }
+        }
+    } else {
+        None
+    }
+}
+
+fn compile_error_stream(message: &str, span: Span) -> TokenStream {
+    fn with_span(mut token_tree: TokenTree, span: Span) -> TokenTree {
+        token_tree.set_span(span);
+        token_tree
+    }
+
+    let message_token = with_span(TokenTree::Literal(Literal::string(message)), span);
+
+    let mut tokens = TokenStream::new();
+    tokens.extend([
+        with_span(TokenTree::Punct(Punct::new(':', Spacing::Joint)), span),
+        with_span(TokenTree::Punct(Punct::new(':', Spacing::Alone)), span),
+        TokenTree::Ident(Ident::new("core", span)),
+        with_span(TokenTree::Punct(Punct::new(':', Spacing::Joint)), span),
+        with_span(TokenTree::Punct(Punct::new(':', Spacing::Alone)), span),
+        TokenTree::Ident(Ident::new("compile_error", span)),
+        with_span(TokenTree::Punct(Punct::new('!', Spacing::Alone)), span),
+        with_span(
+            TokenTree::Group(Group::new(Delimiter::Brace, message_token.into())),
+            span,
+        ),
+    ]);
+
+    tokens
 }

--- a/src/tokens.rs
+++ b/src/tokens.rs
@@ -1,0 +1,113 @@
+use proc_macro::{Delimiter, Group, Ident, Literal, Punct, Spacing, Span, TokenStream, TokenTree};
+
+const EXPECTED_STRING_LITERAL: &str = "expected string literal";
+
+enum ExtractStringError {
+    BadLiteral,
+    EscapeSequence,
+}
+
+pub fn parse_stream<F>(input: TokenStream, process_literal: F) -> TokenStream
+where
+    F: FnOnce(&str, Span) -> TokenStream,
+{
+    let literal = match get_literal(input) {
+        Ok(lit) => lit,
+        Err(tokens) => return tokens,
+    };
+
+    match extract_string_value(&format!("{}", literal)) {
+        Ok(s) => process_literal(s, literal.span()),
+        Err(ExtractStringError::BadLiteral) => {
+            compile_error_stream(EXPECTED_STRING_LITERAL, literal.span())
+        }
+        Err(ExtractStringError::EscapeSequence) => {
+            compile_error_stream("Escape sequences are not supported", literal.span())
+        }
+    }
+}
+
+fn get_literal(input: TokenStream) -> Result<Literal, TokenStream> {
+    let mut trees = input.into_iter();
+    let tree = trees.next().ok_or_else(|| {
+        compile_error_stream(
+            "unexpected end of input, expected string literal",
+            Span::call_site(),
+        )
+    })?;
+
+    if let Some(next_tree) = trees.next() {
+        return Err(compile_error_stream("unexpected token", next_tree.span()));
+    }
+
+    match tree {
+        TokenTree::Literal(literal) => Ok(literal),
+        _ => Err(compile_error_stream(EXPECTED_STRING_LITERAL, tree.span())),
+    }
+}
+
+fn extract_string_value(literal: &str) -> Result<&str, ExtractStringError> {
+    if literal.starts_with('"') {
+        if literal.len() >= 2 && literal.ends_with('"') {
+            // For simplicity, we do not handle any escape sequences. Given the
+            // usage of these macros, they would be of questionable utility.
+            if literal.contains('\\') {
+                return Err(ExtractStringError::EscapeSequence);
+            }
+
+            Ok(&literal[1..(literal.len() - 1)])
+        } else {
+            Err(ExtractStringError::BadLiteral)
+        }
+    } else if literal.starts_with('r') {
+        let mut forward: std::iter::Skip<std::str::CharIndices<'_>> =
+            literal.char_indices().skip(1);
+        let mut reverse = literal.char_indices().rev();
+        loop {
+            let (forward_pos, forward_char) =
+                forward.next().ok_or(ExtractStringError::BadLiteral)?;
+            let (reverse_pos, reverse_char) =
+                reverse.next().ok_or(ExtractStringError::BadLiteral)?;
+            if forward_char != reverse_char || forward_pos >= reverse_pos {
+                return Err(ExtractStringError::BadLiteral);
+            }
+
+            if forward_char == '"' {
+                return Ok(&literal[(forward_pos + 1)..reverse_pos]);
+            }
+
+            if forward_char != '#' {
+                return Err(ExtractStringError::BadLiteral);
+            }
+        }
+    } else {
+        return Err(ExtractStringError::BadLiteral);
+    }
+}
+
+pub fn compile_error_stream(message: &str, span: Span) -> TokenStream {
+    let with_span = |mut token_tree: TokenTree| {
+        token_tree.set_span(span);
+        token_tree
+    };
+
+    let message_token = with_span(TokenTree::Literal(Literal::string(message)));
+
+    // ::core::compile_error!(<message_token>)
+    let mut tokens = TokenStream::new();
+    tokens.extend([
+        with_span(TokenTree::Punct(Punct::new(':', Spacing::Joint))),
+        with_span(TokenTree::Punct(Punct::new(':', Spacing::Alone))),
+        TokenTree::Ident(Ident::new("core", span)),
+        with_span(TokenTree::Punct(Punct::new(':', Spacing::Joint))),
+        with_span(TokenTree::Punct(Punct::new(':', Spacing::Alone))),
+        TokenTree::Ident(Ident::new("compile_error", span)),
+        with_span(TokenTree::Punct(Punct::new('!', Spacing::Alone))),
+        with_span(TokenTree::Group(Group::new(
+            Delimiter::Brace,
+            message_token.into(),
+        ))),
+    ]);
+
+    tokens
+}

--- a/tests/example.rs
+++ b/tests/example.rs
@@ -36,3 +36,12 @@ fn syntax() {
     assert_eq!(hexf32!(r##"-0x2.8p0"##), -2.5f32);
     assert_eq!(hexf64!(r##"-0x2.8p0"##), -2.5f64);
 }
+
+#[test]
+#[rustfmt::skip]
+fn syntax_whitespace() {
+    assert_eq!(hexf32!(  "0x1.0p0"  ), 1.0f32);
+    assert_eq!(hexf64!(
+        "-0x1.8p0"
+    ), -1.5f64);
+}

--- a/tests/example.rs
+++ b/tests/example.rs
@@ -16,6 +16,8 @@ fn negative() {
     assert_eq!(hexf32!("-0x1.99999ap-4"), -0.1f32);
     assert_eq!(hexf64!("-0x1.999999999999ap-4"), -0.1f64);
     assert_eq!(hexf64!("-0x1.999999999998ap-4"), -0.1f64 + f64::EPSILON);
+    assert!(hexf32!("-0x0.0p0").is_sign_negative());
+    assert!(hexf64!("-0x0.0p0").is_sign_negative());
 }
 
 #[test]
@@ -31,4 +33,6 @@ fn syntax() {
     // Raw string literals are handled
     assert_eq!(hexf32!(r"0x1.0p0"), 1.0f32);
     assert_eq!(hexf64!(r"0x1.0p0"), 1.0f64);
+    assert_eq!(hexf32!(r##"-0x2.8p0"##), -2.5f32);
+    assert_eq!(hexf64!(r##"-0x2.8p0"##), -2.5f64);
 }


### PR DESCRIPTION
Since syn is somewhat infamous as a rather heavy crate in the build process, and the input/output of these macros are not too complex, here's a manual implementation.

- The implementation does NOT support escape sequences in string literals, which are of questionable utility here, but this is technically a breaking change.
- I've left in raw string literal support since this was included in the test cases already.