### PR TITLE
Add `no_std` support

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -24,3 +24,26 @@ jobs:
       run: cargo fmt --all -- --check                                           
     - name: Clippy                                                                
       run: cargo clippy --all
+  
+  no_std:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: WASM Core 1.0
+            target: wasm32v1-none
+          - name: Embedded ARM
+            target: thumbv6m-none-eabi
+    
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Install toolchain
+        run: |
+          rustup toolchain install stable --no-self-update --profile=minimal --component clippy
+          rustup target add ${{ matrix.target }} --toolchain stable
+          rustup override set stable
+      - name: Clippy
+        run: cargo clippy --all --target ${{ matrix.target }}

--- a/parse/src/lib.rs
+++ b/parse/src/lib.rs
@@ -17,7 +17,9 @@
 //!
 //! The error is reported via an opaque `ParseHexfError` type.
 
-use std::{f32, f64, fmt, isize, str};
+#![no_std]
+
+use core::{f32, f64, fmt, isize, str};
 
 /// An opaque error type from `parse_hexf32` and `parse_hexf64`.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -58,7 +60,7 @@ impl fmt::Display for ParseHexfError {
     }
 }
 
-impl std::error::Error for ParseHexfError {
+impl core::error::Error for ParseHexfError {
     fn description(&self) -> &'static str {
         self.text()
     }


### PR DESCRIPTION
# Objective

To add `no_std` support to [WGPU](https://github.com/gfx-rs/wgpu/issues/6826), it would be helpful for `hexf` to also be `no_std` compatible.

## Solution

- Add `#![no_std]`
- Switch from `std` to `core`

## Notes

This is my first contribution to this project, please let me know if there's anything I can do to help!