### PR TITLE
Remove unnecessary std feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [docsrs-image]: https://docs.rs/hexf/badge.svg
 [docsrs]: https://docs.rs/hexf/
 
-Hexadecimal float support for Rust 1.43 or later. (For earlier versions, try `0.1.0`)
+No-std hexadecimal float support for Rust 1.43 or later. (For earlier versions, try `0.1.0`)
 
 ```rust
 use hexf::hexf64;

--- a/parse/Cargo.toml
+++ b/parse/Cargo.toml
@@ -12,7 +12,3 @@ edition = "2018"
 
 [dependencies]
 libm = "0.2.2"
-
-[features]
-default = ["std"]
-std = []

--- a/parse/src/lib.rs
+++ b/parse/src/lib.rs
@@ -17,7 +17,7 @@
 //!
 //! The error is reported via an opaque `ParseHexfError` type.
 
-#![cfg_attr(not(feature = "std"), no_std)]
+#![no_std]
 use core::{f32, f64, fmt, isize, str};
 
 /// An opaque error type from `parse_hexf32` and `parse_hexf64`.
@@ -59,14 +59,6 @@ impl fmt::Display for ParseHexfError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for ParseHexfError {
-    fn description(&self) -> &'static str {
-        self.text()
-    }
-}
-
-#[cfg(not(feature = "std"))]
 impl core::error::Error for ParseHexfError {
     fn description(&self) -> &'static str {
         self.text()


### PR DESCRIPTION
This PR removes the unnecessary std feature, making all crates no-std.

Can I also request that before or after this gets merged, a new release is made? Over at wgpu we need (strongly want) a no-std version of this crate before our next release.